### PR TITLE
Support minimum logging level

### DIFF
--- a/DiscordSinkExtenstions.cs
+++ b/DiscordSinkExtenstions.cs
@@ -1,5 +1,6 @@
 using System;
 using Serilog.Configuration;
+using Serilog.Events;
 
 namespace Serilog.Sinks.Discord
 {
@@ -9,10 +10,11 @@ namespace Serilog.Sinks.Discord
                 this LoggerSinkConfiguration loggerConfiguration,
                 UInt64 webhookId,
                 string webhookToken,
-                IFormatProvider formatProvider = null)
+                IFormatProvider formatProvider = null,
+                LogEventLevel restrictedToMinimumLevel = LogEventLevel.Verbose)
         {
             return loggerConfiguration.Sink(
-                new DiscordSink(formatProvider, webhookId, webhookToken));
+                new DiscordSink(formatProvider, webhookId, webhookToken, restrictedToMinimumLevel));
         }
     }
 }


### PR DESCRIPTION
Like in Slack sink, where there is support for minimum logging level, for example:

`loggerConfiguration
                        .WriteTo.Slack(slackChannel, restrictedToMinimumLevel: LogEventLevel.Error)
                        .WriteTo.Discord(discordChannel.WebhookId, discordChannel.WebhookToken)`
                        
This commit adds the same functionality to Discord sink. Usage:

`loggerConfiguration
                        .WriteTo.Slack(slackChannel, restrictedToMinimumLevel: LogEventLevel.Error)
                        .WriteTo.Discord(discordChannel.WebhookId, discordChannel.WebhookToken, restrictedToMinimumLevel: LogEventLevel.Error)`