### PR TITLE
Upgraded sink to net8.0 with latest NuGet updates

### DIFF
--- a/Serilog.Sinks.Discord.csproj
+++ b/Serilog.Sinks.Discord.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+		<TargetFrameworks>net8.0</TargetFrameworks>
     <Authors>Abolfazl Edgelolli</Authors>
-    <Version>1.2.0</Version>
+		<Version>2.0.0</Version>
     <Company>Serilog Contrib</Company>
     <Product>Serilog Discord Sink</Product>
     <NeutralLanguage>aa</NeutralLanguage>

--- a/Serilog.Sinks.Discord.csproj
+++ b/Serilog.Sinks.Discord.csproj
@@ -1,30 +1,30 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
+	<PropertyGroup>
 		<TargetFrameworks>net8.0</TargetFrameworks>
-    <Authors>Abolfazl Edgelolli</Authors>
+		<Authors>Abolfazl Edgelolli</Authors>
 		<Version>2.0.0</Version>
-    <Company>Serilog Contrib</Company>
-    <Product>Serilog Discord Sink</Product>
-    <NeutralLanguage>aa</NeutralLanguage>
-    <PackageDescription>Serilog sink for Discord.</PackageDescription>
-    <RepositoryUrl>https://github.com/AblEdge/Serilog-Sinks-Discrod</RepositoryUrl>
-    <PackageProjectUrl>https://github.com/serilog-contrib/Serilog-Sinks-Discord</PackageProjectUrl>
-    <PackageIcon>SinkIcon.png</PackageIcon>
-	<PackageLicenseExpression>MIT</PackageLicenseExpression>
-  </PropertyGroup>
+		<Company>Serilog Contrib</Company>
+		<Product>Serilog Discord Sink</Product>
+		<NeutralLanguage>aa</NeutralLanguage>
+		<PackageDescription>Serilog sink for Discord.</PackageDescription>
+		<RepositoryUrl>https://github.com/AblEdge/Serilog-Sinks-Discrod</RepositoryUrl>
+		<PackageProjectUrl>https://github.com/serilog-contrib/Serilog-Sinks-Discord</PackageProjectUrl>
+		<PackageIcon>SinkIcon.png</PackageIcon>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <None Include="SinkIcon.png">
-      <Pack>True</Pack>
-      <PackagePath>\</PackagePath>
-    </None>
-  </ItemGroup>
+	<ItemGroup>
+		<None Include="SinkIcon.png">
+			<Pack>True</Pack>
+			<PackagePath>\</PackagePath>
+		</None>
+	</ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Discord.Net.Webhook" Version="3.8.1" />
-    <PackageReference Include="serilog" Version="2.12.0" />
-  </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Discord.Net.Webhook" Version="3.16.0" />
+		<PackageReference Include="serilog" Version="4.1.0" />
+	</ItemGroup>
 
 </Project>
 


### PR DESCRIPTION
Using this in a couple of personal projects fails to restore the NuGet packages due to the reference of an old serilog version.

So for that reason I decided to do a quick PR and upgrading to the latest serilog as well as removing out-of-support .NET versions from the csproj.