### PR TITLE
Update and rename DiscordSinkExtenstions.cs to DiscordSinkExtensions.cs

### DIFF
--- a/DiscordSinkExtensions.cs
+++ b/DiscordSinkExtensions.cs
@@ -4,7 +4,7 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.Discord
 {
-    public static class DiscordSinkExtenstions
+    public static class DiscordSinkExtensions
     {
         public static LoggerConfiguration Discord(
                 this LoggerSinkConfiguration loggerConfiguration,


### PR DESCRIPTION
Hi!
I noticed the file/class has a typo. I understand this may cause a breaking change for some users. Let me know how we should handle this.

Thanks!